### PR TITLE
Disabled states - fixes #73

### DIFF
--- a/demos/checkboxes.html
+++ b/demos/checkboxes.html
@@ -26,12 +26,12 @@
 </div>
 <div>
 	<div class="o-forms-group">
-		<label class="o-forms-label">Label (valid)</label>
-		<input type="checkbox" name="checkbox2" value="1" class="o-forms-checkbox" id="checkbox21" checked="checked" />
+		<label class="o-forms-label">Label (disabled)</label>
+		<input type="checkbox" name="checkbox2" value="1" class="o-forms-checkbox" id="checkbox21" checked="checked" disabled="disabled" />
 		<label for="checkbox21" class="o-forms-label">Checkbox 1</label>
-		<input type="checkbox" name="checkbox2" value="2" class="o-forms-checkbox" id="checkbox22" />
+		<input type="checkbox" name="checkbox2" value="2" class="o-forms-checkbox" id="checkbox22" disabled="disabled" />
 		<label for="checkbox22" class="o-forms-label">Checkbox 2</label>
-		<input type="checkbox" name="checkbox2" value="3" class="o-forms-checkbox" id="checkbox23" />
+		<input type="checkbox" name="checkbox2" value="3" class="o-forms-checkbox" id="checkbox23" disabled="disabled" />
 		<label for="checkbox23" class="o-forms-label">Checkbox 3</label>
 	</div>
 </div>

--- a/demos/radios.html
+++ b/demos/radios.html
@@ -26,12 +26,12 @@
 </div>
 <div>
 	<div class="o-forms-group o-forms--valid">
-		<label class="o-forms-label">Label (valid)</label>
-		<input type="radio" name="radio2" value="1" class="o-forms-radio" id="radio21" checked="checked" />
+		<label class="o-forms-label">Label (disabled)</label>
+		<input type="radio" name="radio2" value="1" class="o-forms-radio" id="radio21" checked="checked" disabled="disabled" />
 		<label for="radio21" class="o-forms-label">Radio 1</label>
-		<input type="radio" name="radio2" value="2" class="o-forms-radio" id="radio22" />
+		<input type="radio" name="radio2" value="2" class="o-forms-radio" id="radio22" disabled="disabled" />
 		<label for="radio22" class="o-forms-label">Radio 2</label>
-		<input type="radio" name="radio2" value="3" class="o-forms-radio" id="radio23" />
+		<input type="radio" name="radio2" value="3" class="o-forms-radio" id="radio23" disabled="disabled" />
 		<label for="radio23" class="o-forms-label">Radio 3</label>
 	</div>
 </div>

--- a/demos/src/checkboxes.mustache
+++ b/demos/src/checkboxes.mustache
@@ -11,12 +11,12 @@
 </div>
 <div>
 	<div class="o-forms-group">
-		<label class="o-forms-label">Label (valid)</label>
-		<input type="checkbox" name="checkbox2" value="1" class="o-forms-checkbox" id="checkbox21" checked="checked" />
+		<label class="o-forms-label">Label (disabled)</label>
+		<input type="checkbox" name="checkbox2" value="1" class="o-forms-checkbox" id="checkbox21" checked="checked" disabled="disabled" />
 		<label for="checkbox21" class="o-forms-label">Checkbox 1</label>
-		<input type="checkbox" name="checkbox2" value="2" class="o-forms-checkbox" id="checkbox22" />
+		<input type="checkbox" name="checkbox2" value="2" class="o-forms-checkbox" id="checkbox22" disabled="disabled" />
 		<label for="checkbox22" class="o-forms-label">Checkbox 2</label>
-		<input type="checkbox" name="checkbox2" value="3" class="o-forms-checkbox" id="checkbox23" />
+		<input type="checkbox" name="checkbox2" value="3" class="o-forms-checkbox" id="checkbox23" disabled="disabled" />
 		<label for="checkbox23" class="o-forms-label">Checkbox 3</label>
 	</div>
 </div>

--- a/demos/src/radios.mustache
+++ b/demos/src/radios.mustache
@@ -10,7 +10,7 @@
 	</div>
 </div>
 <div>
-	<div class="o-forms-group o-forms--valid">
+	<div class="o-forms-group">
 		<label class="o-forms-label">Label (disabled)</label>
 		<input type="radio" name="radio2" value="1" class="o-forms-radio" id="radio21" checked="checked" disabled="disabled" />
 		<label for="radio21" class="o-forms-label">Radio 1</label>

--- a/demos/src/radios.mustache
+++ b/demos/src/radios.mustache
@@ -11,12 +11,12 @@
 </div>
 <div>
 	<div class="o-forms-group o-forms--valid">
-		<label class="o-forms-label">Label (valid)</label>
-		<input type="radio" name="radio2" value="1" class="o-forms-radio" id="radio21" checked="checked" />
+		<label class="o-forms-label">Label (disabled)</label>
+		<input type="radio" name="radio2" value="1" class="o-forms-radio" id="radio21" checked="checked" disabled="disabled" />
 		<label for="radio21" class="o-forms-label">Radio 1</label>
-		<input type="radio" name="radio2" value="2" class="o-forms-radio" id="radio22" />
+		<input type="radio" name="radio2" value="2" class="o-forms-radio" id="radio22" disabled="disabled" />
 		<label for="radio22" class="o-forms-label">Radio 2</label>
-		<input type="radio" name="radio2" value="3" class="o-forms-radio" id="radio23" />
+		<input type="radio" name="radio2" value="3" class="o-forms-radio" id="radio23" disabled="disabled" />
 		<label for="radio23" class="o-forms-label">Radio 3</label>
 	</div>
 </div>

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -20,10 +20,6 @@
 @include oColorsSetUseCase(o-forms-field-focus, border, pink-tint4);
 @include oColorsSetUseCase(o-forms-focus-ring, border, blue-tint5);
 
-@include oColorsSetUseCase(o-forms-field-disabled, text, pink-tint4);
-@include oColorsSetUseCase(o-forms-field-disabled, border, pink-tint2);
-@include oColorsSetUseCase(o-forms-field-disabled, background, pink-tint2);
-
 @include oColorsSetUseCase(o-forms-field-valid, text, grey-tint5);
 @include oColorsSetUseCase(o-forms-field-valid, border, green);
 @include oColorsSetUseCase(o-forms-field-valid, background, white);

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -47,6 +47,7 @@
 
 /// Common field styles: disabled state
 @mixin oFormsCommonFieldDisabled {
+	cursor: default;
 	color: mix(oColorsGetColorFor(o-forms-field-standard, background), oColorsGetColorFor(o-forms-field-standard, text), 70%);
 	border-color: mix(oColorsGetColorFor(o-forms-field-standard, background), oColorsGetColorFor(o-forms-field-standard, border), 50%);
 	background-color: mix(oColorsGetColorFor(o-forms-field-standard, background), oColorsGetColorFor(o-forms-field-standard, border), 85%);

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -47,7 +47,9 @@
 
 /// Common field styles: disabled state
 @mixin oFormsCommonFieldDisabled {
-	@include oColorsFor(o-forms-field-disabled);
+	color: mix(oColorsGetColorFor(o-forms-field-standard, background), oColorsGetColorFor(o-forms-field-standard, text), 70%);
+	border-color: mix(oColorsGetColorFor(o-forms-field-standard, background), oColorsGetColorFor(o-forms-field-standard, border), 50%);
+	background-color: mix(oColorsGetColorFor(o-forms-field-standard, background), oColorsGetColorFor(o-forms-field-standard, border), 85%);
 }
 
 /// Common field styles: invalid state

--- a/src/scss/radio-checkbox.scss
+++ b/src/scss/radio-checkbox.scss
@@ -3,8 +3,9 @@
 /// @link http://registry.origami.ft.com/components/o-forms
 ////
 
-
 /// Radio and checkboxes
+///
+/// Draws a fake control (radio or checkbox) using pseudo-elements
 ///
 /// IE 8: in this mixin we're using ::before and ::after (instead of :before and :after)
 /// so that IE 8 doesn't get enhanced checkboxes (which it wouldn't render correctly anyway)
@@ -33,14 +34,12 @@
 		user-select: none;
 	}
 
-	// styling for small checkbox and radio button labels
 	#{$checkbox}--small + #{$label},
 	#{$radio}--small + #{$label} {
 		padding-left: $_o-forms-radiocheckbox-small-size + 10px;
 		line-height: $_o-forms-radiocheckbox-small-size;
 	}
 
-	// styling for the border of checkboxes
 	#{$checkbox} + #{$label}::before,
 	#{$radio} + #{$label}::before {
 		position: absolute;
@@ -67,7 +66,6 @@
 		@include oFormsCommonFieldFocus;
 	}
 
-	// radio button border styles
 	#{$radio} + #{$label}::before {
 		// Equivalent to border-radius 50%. Fixes an old WebKit bug where rounding wouldn't be applied properly
 		border-radius: 9999px;
@@ -84,7 +82,6 @@
 		border-color: oColorsGetColorFor(o-forms-radiocheckbox-checked, border);
 	}
 
-	// styling for the border of small radio buttons and checkboxes
 	#{$checkbox}--small + #{$label}::before,
 	#{$radio}--small + #{$label}::before {
 		width: $_o-forms-radiocheckbox-small-size;
@@ -107,7 +104,6 @@
 		opacity: 1;
 	}
 
-	// styling for checked radio button
 	#{$radio} + #{$label}::after {
 		background-color: oColorsGetColorFor(o-forms-radiocheckbox-checked, background);
 		border-radius: 50%;
@@ -117,7 +113,6 @@
 		top: ($_o-forms-radiocheckbox-default-size - $_o-forms-radio-internal-default-size) / 2;
 	}
 
-	// styling for small checked radio button
 	#{$radio}--small + #{$label}::after {
 		height: $_o-forms-radio-internal-small-size;
 		width: $_o-forms-radio-internal-small-size;
@@ -125,7 +120,6 @@
 		top: ($_o-forms-radiocheckbox-small-size - $_o-forms-radio-internal-small-size) / 2;
 	}
 
-	// styling for checked checkbox
 	#{$checkbox} + #{$label}::after {
 		background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1NCIgaGVpZ2h0PSI0NiI+PHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTTQzLjM5MSAxLjU1N2wtMjMuMDkyIDIzLjA4OS05Ljc3LTkuNzc0LTkuNjM1IDkuNjQ0IDE5LjM5NSAxOS4zOTcuMDEtLjAyNy4wMzMuMDI3IDMyLjY5My0zMi43Mjl6Ii8+PC9zdmc+');
 		background-repeat: no-repeat;
@@ -135,11 +129,17 @@
 		background-position: 50% 50%;
 	}
 
-	// styling for small checked checkbox
 	#{$checkbox}--small + #{$label}::after {
 		height: $_o-forms-radiocheckbox-small-size;
 		width: $_o-forms-radiocheckbox-small-size;
 		background-size: $_o-forms-radiocheckbox-small-size * 3/4;
+	}
+
+	#{$checkbox}:disabled + #{$label},
+	#{$radio}:disabled + #{$label} {
+		opacity: 0.4;
+		cursor: default;
+		user-select: none;
 	}
 
 	// Positioning fixes for IE 8
@@ -158,7 +158,6 @@
 	}
 }
 
-// styling for checkbox and radio button labels
 @if not $o-forms-is-silent {
 	@include oFormsCheckboxRadio;
 }


### PR DESCRIPTION
- New disabled states for checkboxes and radio buttons (they deserve it, too)
- Disabled inputs don't look like buttons anymore (Fixes #73)

### Before

![screenshot 2014-12-04 18 50 42](https://cloud.githubusercontent.com/assets/85783/5304006/7ef9bba6-7be6-11e4-99f7-7724e771efdb.png)


### After
![screen shot 2015-02-13 at 15 00 50](https://cloud.githubusercontent.com/assets/85783/6189270/3d43c55c-b391-11e4-851a-96ee1f315330.png)

### Colors
Text: default field background (30%) + default text (70%)
Border: default field background (50%) + default border (50%)
Background: default field background (15%) + default border (85%)

**Q: Why not RGBA (transparent colors)?**
A: because plain colours are compatible with older browsers.

**Q: Why mixing colours instead of creating new use cases?**
A: to avoid having to override lots of use cases in their code if a product wants to change the color scheme

#### Next to a normal field, for contrast:
![screen shot 2015-02-13 at 15 00 59](https://cloud.githubusercontent.com/assets/85783/6189272/3ee47884-b391-11e4-8eb5-e33e8c93281b.png)
![screen shot 2015-02-13 at 15 00 50](https://cloud.githubusercontent.com/assets/85783/6189270/3d43c55c-b391-11e4-851a-96ee1f315330.png)

#### Checkboxes

Opacity simply set to 40% because it's simpler than changing colours of checked/unchecked states in combination with the disabled state.

![screen shot 2015-02-13 at 15 25 11](https://cloud.githubusercontent.com/assets/85783/6189879/0369e1b8-b396-11e4-9a4e-217dff1d0d69.png)

![screen shot 2015-02-13 at 15 24 41](https://cloud.githubusercontent.com/assets/85783/6189880/05b3d08c-b396-11e4-9d19-d1d04db86ef5.png)